### PR TITLE
🐛 Fix finishing of ProcessInstances in correlations

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.3",
-    "@process-engine/correlation.contracts": "feature~fix_finishing_of_correlations",
+    "@process-engine/correlation.contracts": "^1.0.2",
     "@process-engine/process_model.contracts": "^2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Contains the service layer for the Correlation API.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.3",
-    "@process-engine/correlation.contracts": "^1.0.0",
+    "@process-engine/correlation.contracts": "feature~fix_finishing_of_correlations",
     "@process-engine/process_model.contracts": "^2.0.0"
   },
   "devDependencies": {

--- a/src/correlation_service.ts
+++ b/src/correlation_service.ts
@@ -156,14 +156,14 @@ export class CorrelationService implements ICorrelationService {
     await this._correlationRepository.deleteCorrelationByProcessModelId(processModelId);
   }
 
-  public async finishCorrelation(identity: IIdentity, correlationId: string): Promise<void> {
+  public async finishProcessInstanceInCorrelation(identity: IIdentity, correlationId: string, processInstanceId: string): Promise<void> {
     await this._iamService.ensureHasClaim(identity, canReadProcessModelClaim);
-    await this._correlationRepository.finishCorrelation(correlationId);
+    await this._correlationRepository.finishProcessInstanceInCorrelation(correlationId, processInstanceId);
   }
 
-  public async finishWithError(identity: IIdentity, correlationId: string, error: Error): Promise<void> {
+  public async finishProcessInstanceInCorrelationWithError(identity: IIdentity, correlationId: string, processInstanceId: string, error: Error): Promise<void> {
     await this._iamService.ensureHasClaim(identity, canReadProcessModelClaim);
-    await this._correlationRepository.finishWithError(correlationId, error);
+    await this._correlationRepository.finishProcessInstanceInCorrelationWithError(correlationId, processInstanceId, error);
   }
 
   private _filterCorrelationsFromRepoByIdentity(

--- a/src/correlation_service.ts
+++ b/src/correlation_service.ts
@@ -161,7 +161,12 @@ export class CorrelationService implements ICorrelationService {
     await this._correlationRepository.finishProcessInstanceInCorrelation(correlationId, processInstanceId);
   }
 
-  public async finishProcessInstanceInCorrelationWithError(identity: IIdentity, correlationId: string, processInstanceId: string, error: Error): Promise<void> {
+  public async finishProcessInstanceInCorrelationWithError(
+    identity: IIdentity,
+    correlationId: string,
+    processInstanceId: string,
+    error: Error,
+  ): Promise<void> {
     await this._iamService.ensureHasClaim(identity, canReadProcessModelClaim);
     await this._correlationRepository.finishProcessInstanceInCorrelationWithError(correlationId, processInstanceId, error);
   }


### PR DESCRIPTION
**Changes:**

Account for the ProcessInstanceId when attempting to finish something within a Correlation.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/274

PR: #3

## How can others test the changes?

Finishing a ProcessInstance in a Correlation will now work properly.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).