### PR TITLE
✨ Add Queries for retrieving ProcessInstances

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "@essential-projects/eslint-config"
+  "extends": "@essential-projects/eslint-config",
+  "rules": {
+    "no-null/no-null": ["off"]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.3",
     "@process-engine/correlation.contracts": "feature~flatten_correlation_types",
-    "@process-engine/process_model.contracts": "2.7.0-acad6f21-b10",
+    "@process-engine/process_model.contracts": "2.7.0-alpha.1",
     "loggerhythm": "^3.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/process-engine/correlation.service#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.3",
-    "@process-engine/correlation.contracts": "feature~flatten_correlation_types",
+    "@process-engine/correlation.contracts": "3.0.0-alpha.1",
     "@process-engine/process_model.contracts": "2.7.0-alpha.1",
     "loggerhythm": "^3.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
     "@process-engine/ci_tools": "^2.0.0",
+    "@types/bluebird-global": "^3.5.9",
     "@types/node": "^10.12.10",
     "eslint": "^5.16.0",
     "tsconfig": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/correlation.service",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Contains the service layer for the Correlation API.",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/process-engine/correlation.service#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.3",
-    "@process-engine/correlation.contracts": "2.2.0-cf63a55e-b11",
+    "@process-engine/correlation.contracts": "feature~flatten_correlation_types",
     "@process-engine/process_model.contracts": "2.7.0-acad6f21-b10",
     "loggerhythm": "^3.0.3"
   },

--- a/src/correlation_service.ts
+++ b/src/correlation_service.ts
@@ -179,7 +179,7 @@ export class CorrelationService implements ICorrelationService {
 
     const noCorrelationsFound = !processInstancesFromRepo || processInstancesFromRepo.length === 0;
     if (noCorrelationsFound) {
-      throw new NotFoundError(`Correlation with id "${correlationId}" not found.`);
+      throw new NotFoundError(`No ProcessInstances for Correlation with id "${correlationId}" found.`);
     }
 
     const filteredProcessInstancesFromRepo = await this.filterProcessInstancesFromRepoByIdentity(identity, processInstancesFromRepo);

--- a/src/correlation_service.ts
+++ b/src/correlation_service.ts
@@ -149,6 +149,72 @@ export class CorrelationService implements ICorrelationService {
     return processInstances;
   }
 
+  public async getProcessInstancesForCorrelation(
+    identity: IIdentity,
+    correlationId: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<Array<ProcessInstance>> {
+    await this.ensureUserHasClaim(identity, canReadProcessModelClaim);
+
+    const processInstancesFromRepo = await this.correlationRepository.getByCorrelationId(correlationId);
+
+    const filteredProcessInstancesFromRepo = await this.filterProcessInstancesFromRepoByIdentity(identity, processInstancesFromRepo);
+
+    if (filteredProcessInstancesFromRepo.length === 0) {
+      return undefined;
+    }
+
+    const processInstances =
+      await Promise.map<ProcessInstanceFromRepository, ProcessInstance>(filteredProcessInstancesFromRepo, this.mapProcessInstance.bind(this));
+
+    return processInstances;
+  }
+
+  public async getProcessInstancesForProcessModel(
+    identity: IIdentity,
+    processModelId: string,
+    offset?: number,
+    limit?: number,
+  ): Promise<Array<ProcessInstance>> {
+    await this.ensureUserHasClaim(identity, canReadProcessModelClaim);
+
+    const processInstancesFromRepo = await this.correlationRepository.getByProcessModelId(processModelId);
+
+    const filteredProcessInstancesFromRepo = await this.filterProcessInstancesFromRepoByIdentity(identity, processInstancesFromRepo);
+
+    if (filteredProcessInstancesFromRepo.length === 0) {
+      return undefined;
+    }
+
+    const processInstances =
+      await Promise.map<ProcessInstanceFromRepository, ProcessInstance>(filteredProcessInstancesFromRepo, this.mapProcessInstance.bind(this));
+
+    return processInstances;
+  }
+
+  public async getProcessInstancesByState(
+    identity: IIdentity,
+    state: CorrelationState,
+    offset?: number,
+    limit?: number,
+  ): Promise<Array<ProcessInstance>> {
+    await this.ensureUserHasClaim(identity, canReadProcessModelClaim);
+
+    const processInstancesFromRepo = await this.correlationRepository.getCorrelationsByState(state);
+
+    const filteredProcessInstancesFromRepo = await this.filterProcessInstancesFromRepoByIdentity(identity, processInstancesFromRepo);
+
+    if (filteredProcessInstancesFromRepo.length === 0) {
+      return undefined;
+    }
+
+    const processInstances =
+      await Promise.map<ProcessInstanceFromRepository, ProcessInstance>(filteredProcessInstancesFromRepo, this.mapProcessInstance.bind(this));
+
+    return processInstances;
+  }
+
   public async deleteCorrelationByProcessModelId(identity: IIdentity, processModelId: string): Promise<void> {
     await this.ensureUserHasClaim(identity, canDeleteProcessModel);
     await this.correlationRepository.deleteCorrelationByProcessModelId(processModelId);

--- a/src/correlation_service.ts
+++ b/src/correlation_service.ts
@@ -93,6 +93,11 @@ export class CorrelationService implements ICorrelationService {
 
     const correlationsFromRepo = await this.correlationRepository.getByProcessModelId(processModelId);
 
+    const noCorrelationsFound = !correlationsFromRepo || correlationsFromRepo.length === 0;
+    if (noCorrelationsFound) {
+      throw new NotFoundError(`No correlations for ProcessModel with ID "${processModelId}" found.`);
+    }
+
     const filteredCorrelationsFromRepo = await this.filterProcessInstancesFromRepoByIdentity(identity, correlationsFromRepo);
 
     const correlations = await this.mapCorrelationList(filteredCorrelationsFromRepo);
@@ -108,6 +113,11 @@ export class CorrelationService implements ICorrelationService {
     // NOTE:
     // These will already be ordered by their createdAt value, with the oldest one at the top.
     const correlationsFromRepo = await this.correlationRepository.getByCorrelationId(correlationId);
+
+    const noCorrelationsFound = !correlationsFromRepo || correlationsFromRepo.length === 0;
+    if (noCorrelationsFound) {
+      throw new NotFoundError(`Correlation with id "${correlationId}" not found.`);
+    }
 
     const filteredCorrelationsFromRepo = await this.filterProcessInstancesFromRepoByIdentity(identity, correlationsFromRepo);
 
@@ -167,6 +177,11 @@ export class CorrelationService implements ICorrelationService {
 
     const processInstancesFromRepo = await this.correlationRepository.getByCorrelationId(correlationId);
 
+    const noCorrelationsFound = !processInstancesFromRepo || processInstancesFromRepo.length === 0;
+    if (noCorrelationsFound) {
+      throw new NotFoundError(`Correlation with id "${correlationId}" not found.`);
+    }
+
     const filteredProcessInstancesFromRepo = await this.filterProcessInstancesFromRepoByIdentity(identity, processInstancesFromRepo);
 
     if (filteredProcessInstancesFromRepo.length === 0) {
@@ -189,6 +204,11 @@ export class CorrelationService implements ICorrelationService {
 
     const processInstancesFromRepo = await this.correlationRepository.getByProcessModelId(processModelId);
 
+    const noProcessInstancesFound = !processInstancesFromRepo || processInstancesFromRepo.length === 0;
+    if (noProcessInstancesFound) {
+      throw new NotFoundError(`No ProcessInstances for ProcessModel with ID "${processModelId}" found.`);
+    }
+
     const filteredProcessInstancesFromRepo = await this.filterProcessInstancesFromRepoByIdentity(identity, processInstancesFromRepo);
 
     if (filteredProcessInstancesFromRepo.length === 0) {
@@ -210,6 +230,11 @@ export class CorrelationService implements ICorrelationService {
     await this.ensureUserHasClaim(identity, canReadProcessModelClaim);
 
     const processInstancesFromRepo = await this.correlationRepository.getCorrelationsByState(state);
+
+    const noProcessInstancesFound = !processInstancesFromRepo || processInstancesFromRepo.length === 0;
+    if (noProcessInstancesFound) {
+      throw new NotFoundError(`No ProcessInstances in a "${state}" state found.`);
+    }
 
     const filteredProcessInstancesFromRepo = await this.filterProcessInstancesFromRepoByIdentity(identity, processInstancesFromRepo);
 

--- a/src/correlation_service.ts
+++ b/src/correlation_service.ts
@@ -6,11 +6,11 @@ import {NotFoundError} from '@essential-projects/errors_ts';
 
 import {
   Correlation,
-  CorrelationFromRepository,
-  CorrelationProcessInstance,
   CorrelationState,
   ICorrelationRepository,
   ICorrelationService,
+  ProcessInstance,
+  ProcessInstanceFromRepository,
 } from '@process-engine/correlation.contracts';
 
 import {IProcessDefinitionRepository} from '@process-engine/process_model.contracts';
@@ -23,7 +23,7 @@ const logger = Logger.createLogger('processengine:correlation:service');
  * Only use internally.
  */
 type GroupedCorrelations = {
-  [correlationId: string]: Array<CorrelationFromRepository>;
+  [correlationId: string]: Array<ProcessInstanceFromRepository>;
 };
 
 const superAdminClaim = 'can_manage_process_instances';
@@ -65,7 +65,7 @@ export class CorrelationService implements ICorrelationService {
 
     const correlationsFromRepo = await this.correlationRepository.getAll();
 
-    const filteredCorrelationsFromRepo = await this.filterCorrelationsFromRepoByIdentity(identity, correlationsFromRepo);
+    const filteredCorrelationsFromRepo = await this.filterProcessInstancesFromRepoByIdentity(identity, correlationsFromRepo);
 
     const correlations = await this.mapCorrelationList(filteredCorrelationsFromRepo);
 
@@ -79,7 +79,7 @@ export class CorrelationService implements ICorrelationService {
 
     const activeCorrelationsFromRepo = await this.correlationRepository.getCorrelationsByState(CorrelationState.running);
 
-    const filteredCorrelationsFromRepo = await this.filterCorrelationsFromRepoByIdentity(identity, activeCorrelationsFromRepo);
+    const filteredCorrelationsFromRepo = await this.filterProcessInstancesFromRepoByIdentity(identity, activeCorrelationsFromRepo);
 
     const activeCorrelationsForIdentity = await this.mapCorrelationList(filteredCorrelationsFromRepo);
 
@@ -93,7 +93,7 @@ export class CorrelationService implements ICorrelationService {
 
     const correlationsFromRepo = await this.correlationRepository.getByProcessModelId(processModelId);
 
-    const filteredCorrelationsFromRepo = await this.filterCorrelationsFromRepoByIdentity(identity, correlationsFromRepo);
+    const filteredCorrelationsFromRepo = await this.filterProcessInstancesFromRepoByIdentity(identity, correlationsFromRepo);
 
     const correlations = await this.mapCorrelationList(filteredCorrelationsFromRepo);
 
@@ -109,7 +109,7 @@ export class CorrelationService implements ICorrelationService {
     // These will already be ordered by their createdAt value, with the oldest one at the top.
     const correlationsFromRepo = await this.correlationRepository.getByCorrelationId(correlationId);
 
-    const filteredCorrelationsFromRepo = await this.filterCorrelationsFromRepoByIdentity(identity, correlationsFromRepo);
+    const filteredCorrelationsFromRepo = await this.filterProcessInstancesFromRepoByIdentity(identity, correlationsFromRepo);
 
     // All correlations will have the same ID here, so we can just use the top entry as a base.
     const noFilteredCorrelationsFromRepo = filteredCorrelationsFromRepo.length === 0;
@@ -117,36 +117,36 @@ export class CorrelationService implements ICorrelationService {
       throw new NotFoundError('No such correlations for the user.');
     }
 
-    const correlation = await this.mapCorrelation(correlationsFromRepo[0].id, correlationsFromRepo);
+    const correlation = await this.mapCorrelation(correlationsFromRepo[0].correlationId, correlationsFromRepo);
 
     return correlation;
   }
 
-  public async getByProcessInstanceId(identity: IIdentity, processInstanceId: string): Promise<Correlation> {
+  public async getByProcessInstanceId(identity: IIdentity, processInstanceId: string): Promise<ProcessInstance> {
     await this.ensureUserHasClaim(identity, canReadProcessModelClaim);
 
-    const correlationFromRepo = await this.correlationRepository.getByProcessInstanceId(processInstanceId);
+    const processInstanceFromRepo = await this.correlationRepository.getByProcessInstanceId(processInstanceId);
 
-    const correlation = await this.mapCorrelation(correlationFromRepo.id, [correlationFromRepo]);
+    const processInstance = await this.mapProcessInstance(processInstanceFromRepo);
 
-    return correlation;
+    return processInstance;
   }
 
-  public async getSubprocessesForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<Correlation> {
+  public async getSubprocessesForProcessInstance(identity: IIdentity, processInstanceId: string): Promise<Array<ProcessInstance>> {
     await this.ensureUserHasClaim(identity, canReadProcessModelClaim);
 
-    const correlationsFromRepo = await this.correlationRepository.getSubprocessesForProcessInstance(processInstanceId);
+    const processInstancesFromRepo = await this.correlationRepository.getSubprocessesForProcessInstance(processInstanceId);
 
-    const filteredCorrelationsFromRepo = await this.filterCorrelationsFromRepoByIdentity(identity, correlationsFromRepo);
+    const filteredProcessInstancesFromRepo = await this.filterProcessInstancesFromRepoByIdentity(identity, processInstancesFromRepo);
 
-    const noFilteredCorrelations = filteredCorrelationsFromRepo.length === 0;
-    if (noFilteredCorrelations) {
+    if (filteredProcessInstancesFromRepo.length === 0) {
       return undefined;
     }
 
-    const correlation = await this.mapCorrelation(correlationsFromRepo[0].id, correlationsFromRepo);
+    const processInstances =
+      await Promise.map<ProcessInstanceFromRepository, ProcessInstance>(filteredProcessInstancesFromRepo, this.mapProcessInstance.bind(this));
 
-    return correlation;
+    return processInstances;
   }
 
   public async deleteCorrelationByProcessModelId(identity: IIdentity, processModelId: string): Promise<void> {
@@ -169,10 +169,10 @@ export class CorrelationService implements ICorrelationService {
     await this.correlationRepository.finishProcessInstanceInCorrelationWithError(correlationId, processInstanceId, error);
   }
 
-  private async filterCorrelationsFromRepoByIdentity(
+  private async filterProcessInstancesFromRepoByIdentity(
     identity: IIdentity,
-    correlationsFromRepo: Array<CorrelationFromRepository>,
-  ): Promise<Array<CorrelationFromRepository>> {
+    correlationsFromRepo: Array<ProcessInstanceFromRepository>,
+  ): Promise<Array<ProcessInstanceFromRepository>> {
 
     const userIsSuperAdmin = identity.userId !== 'dummy_token' && await this.checkIfUserIsSuperAdmin(identity);
 
@@ -181,7 +181,7 @@ export class CorrelationService implements ICorrelationService {
       return correlationsFromRepo;
     }
 
-    return correlationsFromRepo.filter((correlationFromRepo: CorrelationFromRepository): boolean => {
+    return correlationsFromRepo.filter((correlationFromRepo: ProcessInstanceFromRepository): boolean => {
 
       // Correlations that were created with the dummy token are visible to everybody.
       const isDummyToken = correlationFromRepo.identity.userId === 'dummy_token';
@@ -191,7 +191,7 @@ export class CorrelationService implements ICorrelationService {
     });
   }
 
-  private async mapCorrelationList(correlationsFromRepo: Array<CorrelationFromRepository>): Promise<Array<Correlation>> {
+  private async mapCorrelationList(correlationsFromRepo: Array<ProcessInstanceFromRepository>): Promise<Array<Correlation>> {
     const groupedCorrelations = this.groupCorrelations(correlationsFromRepo);
 
     const uniqueCorrelationIds = Object.keys(groupedCorrelations);
@@ -208,19 +208,19 @@ export class CorrelationService implements ICorrelationService {
     return mappedCorrelations;
   }
 
-  private groupCorrelations(correlations: Array<CorrelationFromRepository>): GroupedCorrelations {
+  private groupCorrelations(correlations: Array<ProcessInstanceFromRepository>): GroupedCorrelations {
 
     const groupedCorrelations: GroupedCorrelations = {};
 
     for (const correlation of correlations) {
 
-      const groupHasNoMatchingEntry = !groupedCorrelations[correlation.id];
+      const groupHasNoMatchingEntry = !groupedCorrelations[correlation.correlationId];
 
       if (groupHasNoMatchingEntry) {
-        groupedCorrelations[correlation.id] = [];
+        groupedCorrelations[correlation.correlationId] = [];
       }
 
-      groupedCorrelations[correlation.id].push(correlation);
+      groupedCorrelations[correlation.correlationId].push(correlation);
     }
 
     return groupedCorrelations;
@@ -228,58 +228,64 @@ export class CorrelationService implements ICorrelationService {
 
   private async mapCorrelation(
     correlationId: string,
-    correlationsFromRepo?: Array<CorrelationFromRepository>,
+    processInstancesFromRepo?: Array<ProcessInstanceFromRepository>,
   ): Promise<Correlation> {
 
-    const parsedCorrelation = new Correlation();
-    parsedCorrelation.id = correlationId;
-    parsedCorrelation.createdAt = correlationsFromRepo[0].createdAt;
+    const correlation = new Correlation();
+    correlation.id = correlationId;
+    correlation.createdAt = processInstancesFromRepo[0].createdAt;
 
-    if (correlationsFromRepo) {
-      parsedCorrelation.processInstances = [];
+    if (processInstancesFromRepo) {
+      correlation.processInstances = [];
 
-      for (const correlationFromRepo of correlationsFromRepo) {
+      for (const processInstanceFromRepo of processInstancesFromRepo) {
 
         /**
          * As long as there is at least one running ProcessInstance within a correlation,
          * the correlation will always have a running state, no matter how many
          * "finished" instances there might be.
          */
-        parsedCorrelation.state = parsedCorrelation.state !== CorrelationState.running
-          ? correlationFromRepo.state
+        correlation.state = correlation.state !== CorrelationState.running
+          ? processInstanceFromRepo.state
           : CorrelationState.running;
 
-        // Sequelize returns "null"-value column as an actual null, so null-checks are required here.
-        // eslint-disable-next-line no-null/no-null
-        const correlationEntryHasErrorAttached = correlationFromRepo.error !== undefined && correlationFromRepo.error !== null;
-
-        if (correlationEntryHasErrorAttached) {
-          parsedCorrelation.state = CorrelationState.error;
-          parsedCorrelation.error = correlationFromRepo.error;
+        const processInstanceHasErrorAttached = processInstanceFromRepo.error !== undefined && processInstanceFromRepo.error !== null;
+        if (processInstanceHasErrorAttached) {
+          correlation.state = CorrelationState.error;
+          correlation.error = processInstanceFromRepo.error;
         }
 
-        const processDefinition = await this.processDefinitionRepository.getByHash(correlationFromRepo.processModelHash);
+        const processInstance = await this.mapProcessInstance(processInstanceFromRepo);
 
-        const processModel = new CorrelationProcessInstance();
-        processModel.processDefinitionName = processDefinition.name;
-        processModel.xml = processDefinition.xml;
-        processModel.hash = correlationFromRepo.processModelHash;
-        processModel.processModelId = correlationFromRepo.processModelId;
-        processModel.processInstanceId = correlationFromRepo.processInstanceId;
-        processModel.parentProcessInstanceId = correlationFromRepo.parentProcessInstanceId;
-        processModel.createdAt = correlationFromRepo.createdAt;
-        processModel.state = correlationFromRepo.state;
-        processModel.identity = correlationFromRepo.identity;
-
-        if (correlationEntryHasErrorAttached) {
-          processModel.error = correlationFromRepo.error;
-        }
-
-        parsedCorrelation.processInstances.push(processModel);
+        correlation.processInstances.push(processInstance);
       }
     }
 
-    return parsedCorrelation;
+    return correlation;
+  }
+
+  private async mapProcessInstance(processInstanceFromRepo: ProcessInstanceFromRepository): Promise<ProcessInstance> {
+
+    const processDefinition = await this.processDefinitionRepository.getByHash(processInstanceFromRepo.processModelHash);
+
+    const processInstance = new ProcessInstance();
+    processInstance.correlationId = processInstanceFromRepo.correlationId;
+    processInstance.processDefinitionName = processDefinition.name;
+    processInstance.xml = processDefinition.xml;
+    processInstance.hash = processInstanceFromRepo.processModelHash;
+    processInstance.processModelId = processInstanceFromRepo.processModelId;
+    processInstance.processInstanceId = processInstanceFromRepo.processInstanceId;
+    processInstance.parentProcessInstanceId = processInstanceFromRepo.parentProcessInstanceId;
+    processInstance.createdAt = processInstanceFromRepo.createdAt;
+    processInstance.state = processInstanceFromRepo.state;
+    processInstance.identity = processInstanceFromRepo.identity;
+
+    const processInstanceHasErrorAttached = processInstanceFromRepo.error !== undefined && processInstanceFromRepo.error !== null;
+    if (processInstanceHasErrorAttached) {
+      processInstance.error = processInstanceFromRepo.error;
+    }
+
+    return processInstance;
   }
 
   private applyPagination(correlations: Array<Correlation>, offset: number, limit: number): Array<Correlation> {


### PR DESCRIPTION
## Changes

1. Add UseCases for getting ProcessInstances:
    - getProcessInstancesForCorrelation
    - getProcessInstancesForProcessModel
    - getProcessInstancesByState
2. Add `correlationId` property to `ProcessInstance` type
3. Change return type of `ICorrelationService.getByProcessInstanceId` to `ProcessInstance`
4. Change return type of `getSubprocessesForProcessInstance` to `Array<ProcessInstance>`
5. Import error handling from `CorrelationRepository`

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/404

PR: #8